### PR TITLE
Clearing an Update Issue where keys don't copy.

### DIFF
--- a/Setup-Arma3Server.ps1
+++ b/Setup-Arma3Server.ps1
@@ -25,7 +25,7 @@
 .PARAMETER mods
 
     An array of mods to download for Arma3 Server. seperate like: 'mod','mod2','mod3'
-    MUST use the Steam ID. For example to install CBA_A3, it would be 450814997. Taken from https://steamcommunity.com/sharedfiles/filedetails/?id=450814997
+    must use the Steam ID. For example to install CBA_A3, it would be 450814997. Taken from https://steamcommunity.com/sharedfiles/filedetails/?id=450814997
 
 .EXAMPLE
     

--- a/Setup-Arma3Server.ps1
+++ b/Setup-Arma3Server.ps1
@@ -57,7 +57,6 @@ Param
 $SteamCMDDownloadURL = 'https://steamcdn-a.akamaihd.net/client/installer/steamcmd.zip'
 $Arma3ServerID = '233780'
 $Arma3ID = '107410'
-$NSSMDownloadURL = 'https://nssm.cc/release/nssm-2.24.zip'
 $CredentialFile = 'ServerLogin.cred'
 ####/vars####
 

--- a/Start-Arma3Server.ps1
+++ b/Start-Arma3Server.ps1
@@ -36,14 +36,13 @@ Param(
 
 ##### Variables #####
 #App ID is 233780 for Arma3 Server
-$AppID = '233780'
 $AppInstallDir = $SteamCMDinstallPath + "\" + $Arma3ServerName
 $originalLocation = Get-Location
 ##### /Variables #####
 
 #Check SteamCMD exists.
 Set-Location -Path $SteamCMDinstallPath
-$SteamCMDCheck = Test-Path -Path ".\Steamcmd.exe"
+Test-Path -Path ".\Steamcmd.exe"
 
 #removing the final ; from the modlist to allow ARMA to load mods properly.
 foreach($mod in $Mods){

--- a/Update-Arma3Server.ps1
+++ b/Update-Arma3Server.ps1
@@ -1,5 +1,5 @@
 ﻿<#
-.SYNOPSIS 
+.SYNOPSIS
     A POSH script to update an arma3 server that's been created with Setup-Arma3Server.ps1
 
 .PARAMETER SteamCMDinstallPath
@@ -11,17 +11,17 @@
     Name of the Arma3 server.
 
 .PARAMETER ServerConfigFileLocation
-    
+
     The name of the config file for the server, if you use one. Should ideally be in the Arma 3 Server directory.
 
 .PARAMETER ModsToUpdate
-    
+
     A list of mods to update, using their steam numbers in the format of: "000000","000001","00125"
 
 .NOTES
     AUTHOR: Caius Ajiz
     WEBSITE: https://github.com/CaiusAjiz/Arma3Powershell/
-#> 
+#>
 
 Param(
     [Parameter(Mandatory=$true)]
@@ -36,7 +36,7 @@ Param(
 #App ID is 233780 for Arma3 Server
 $AppID = '233780'
 $Arma3Id = '107410'
-$WorkShopPath = $SteamCMDinstallPath + '\steamapps\workshop\content\107410\'
+$WorkShopPath = $SteamCMDinstallPath + '\steamapps\workshop\content\107410'
 $CredentialFile = 'ServerLogin.cred'
 $OriginalLocation = Get-Location
 $AppInstallDir = $SteamCMDinstallPath + "\" + $Arma3ServerName
@@ -52,14 +52,14 @@ $UserName = $CredentialHash.Username
 $Password = (New-Object System.Management.Automation.PSCredential -ArgumentList $CredentialHash.Username,$CredentialHash.Password).GetNetworkCredential().Password
 
 #Updates Arma3 server and validates files
-If($SteamCMDCheck -eq "True"){ 
-        .\SteamCMD.exe +login $UserName $Password +force_install_dir $AppInstallDir +app_update $AppID validate +quit                
+If($SteamCMDCheck -eq "True"){
+        .\SteamCMD.exe +login $UserName $Password +force_install_dir $AppInstallDir +app_update $AppID validate +quit
     }else{
         throw "SteamCMD doesn't exist in $SteamCmdDir, exiting"
          }
 #Installs mods to C:\steamcmd\steamapps\workshop\content\107410. can't be changed. Then makes a link in the correct area so it can be called later.
 Foreach ($Mod in $ModsToUpdate){
-    #Mod DL from workshop 
+    #Mod DL from workshop
     .\SteamCMD.exe +login $UserName $Password +workshop_download_item $Arma3Id $Mod validate +quit
 
     #copy folders as creating shortcuts doesn't work

--- a/Update-Arma3Server.ps1
+++ b/Update-Arma3Server.ps1
@@ -36,7 +36,7 @@ Param(
 #App ID is 233780 for Arma3 Server
 $AppID = '233780'
 $Arma3Id = '107410'
-$WorkShopPath = $SteamCMDinstallPath + '\steamapps\workshop\content\107410'
+$WorkShopPath = $SteamCMDinstallPath + '\steamapps\workshop\content\107410\'
 $CredentialFile = 'ServerLogin.cred'
 $OriginalLocation = Get-Location
 $AppInstallDir = $SteamCMDinstallPath + "\" + $Arma3ServerName
@@ -57,15 +57,15 @@ If($SteamCMDCheck -eq "True"){
     }else{
         throw "SteamCMD doesn't exist in $SteamCmdDir, exiting"
          }
-#Installs mods to C:\steamcmd\steamapps\workshop\content\107410. can't be changed. Then makes a link in the correct area so it can be called later.
+#Installs mods to .\steamcmd\steamapps\workshop\content\107410. can't be changed. Then makes a link in the correct area so it can be called later.
 Foreach ($Mod in $ModsToUpdate){
     #Mod DL from workshop
     .\SteamCMD.exe +login $UserName $Password +workshop_download_item $Arma3Id $Mod validate +quit
 
     #copy folders as creating shortcuts doesn't work
     $source = $WorkShopPath + "$Mod"
-    $destination = $AppInstallDir + "\" + "$Mod"
-    $destinationKeyFolder = $AppInstallDir + "keys"
+    $destination = $AppInstallDir
+    $destinationKeyFolder = $AppInstallDir + "\keys"
     #Copy whole Folder to the install Dir, which is required to load. Arma expects the folders to be in one area.
     Copy-Item -Path $source -Destination $destination -Recurse -Force -Verbose
     #Copy the bikeys to the Servers keys folder because nothing's ever easy.


### PR DESCRIPTION
Keys wouldn't copy if a trailing slash was left. Corrected.